### PR TITLE
Fixed post-build event failing

### DIFF
--- a/Code/Client/Inbox2/Core/LauncherCommands/Inbox2.Core.LauncherCommands.csproj
+++ b/Code/Client/Inbox2/Core/LauncherCommands/Inbox2.Core.LauncherCommands.csproj
@@ -198,6 +198,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)*.*" "..\..\..\..\..\..\..\Client\Inbox2\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)*.*" "$(SolutionDir)\Client\Inbox2\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Code/Client/Inbox2/Plugins/ColumnSearch/Inbox2.Plugins.ColumnSearch.csproj
+++ b/Code/Client/Inbox2/Plugins/ColumnSearch/Inbox2.Plugins.ColumnSearch.csproj
@@ -195,7 +195,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)*.*" "..\..\..\..\..\..\..\Client\Inbox2\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)*.*" "$(SolutionDir)\Client\Inbox2\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Code/Client/Inbox2/Plugins/Contacts/Inbox2.Plugins.Contacts.csproj
+++ b/Code/Client/Inbox2/Plugins/Contacts/Inbox2.Plugins.Contacts.csproj
@@ -293,6 +293,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)*.*" "..\..\..\..\..\..\..\Client\Inbox2\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)*.*" "$(SolutionDir)\Client\Inbox2\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Code/Client/Inbox2/Plugins/Conversations/Inbox2.Plugins.Conversations.csproj
+++ b/Code/Client/Inbox2/Plugins/Conversations/Inbox2.Plugins.Conversations.csproj
@@ -375,6 +375,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)*.*" "..\..\..\..\..\..\..\Client\Inbox2\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)*.*" "$(SolutionDir)\Client\Inbox2\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Code/Client/Inbox2/Plugins/Documents/Inbox2.Plugins.Documents.csproj
+++ b/Code/Client/Inbox2/Plugins/Documents/Inbox2.Plugins.Documents.csproj
@@ -303,6 +303,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)*.*" "..\..\..\..\..\..\..\Client\Inbox2\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)*.*" "$(SolutionDir)\Client\Inbox2\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Code/Client/Inbox2/Plugins/StatusUpdates/Inbox2.Plugins.StatusUpdates.csproj
+++ b/Code/Client/Inbox2/Plugins/StatusUpdates/Inbox2.Plugins.StatusUpdates.csproj
@@ -244,7 +244,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)*.*" "..\..\..\..\..\..\..\Client\Inbox2\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetDir)*.*" "$(SolutionDir)\Client\Inbox2\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Post build file copies were causing build failures. Using $(SolutionDir) macro instead of relative paths instead now.
